### PR TITLE
Fixes error saying 'ctypes.util' was not found

### DIFF
--- a/thorlabs_apt/core.py
+++ b/thorlabs_apt/core.py
@@ -2,6 +2,7 @@ from . import _APTAPI
 from . import _error_codes
 
 import ctypes
+import ctypes.util
 import os
 import sys
 


### PR DESCRIPTION
Fix #4 
