### PR TITLE
Bugfix of backlash_distance property.

### DIFF
--- a/thorlabs_apt/core.py
+++ b/thorlabs_apt/core.py
@@ -564,7 +564,7 @@ class Motor(object):
             return backlash.value
 
     @backlash_distance.setter
-    def blacklash_distance(self, value):
+    def backlash_distance(self, value):
         err_code = _lib.MOT_SetBLashDist(self._serial_number, value)
         if (err_code != 0):
             raise Exception("Setting backlash distance failed: %s" %


### PR DESCRIPTION
Backlash setter property had a typo making the property unusable.